### PR TITLE
fix: SDK generation overrides and package details

### DIFF
--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -21,3 +21,5 @@
 #docs/*.md
 # Then explicitly reverse the ignore rule for a single file:
 #!docs/README.md
+
+package.json

--- a/package.json
+++ b/package.json
@@ -1,20 +1,22 @@
 {
-    "name": "whispir-node",
+    "name": "whispir",
     "version": "1.0.0",
-    "description": "NodeJS client for whispir-node",
+    "description": "Whispir API wrapper",
+    "keywords": [
+        "whispir",
+        "api",
+        "messaging"
+    ],
+    "homepage": "https://github.com/whispir/whispir-node",
+    "author": "Whispir <support@whispir.com> (https://whispir.com)",
     "repository": {
         "type": "git",
-        "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
+        "url": "git://github.com/whispir/whispir-node.git"
     },
+    "bugs": "https://github.com/whispir/whispir-node/issues",
     "main": "dist/api.js",
     "types": "dist/api.d.ts",
-    "scripts": {
-        "clean": "rm -Rf node_modules/ *.js",
-        "build": "tsc",
-        "test": "npm run build && node dist/client.js"
-    },
-    "author": "OpenAPI-Generator Contributors",
-    "license": "Unlicense",
+    "license": "MIT",
     "dependencies": {
         "bluebird": "^3.5.0",
         "request": "^2.81.0",
@@ -25,5 +27,10 @@
         "@types/node": "^12",
         "@types/request": "^2.48.8",
         "typescript": "^4.0"
+    },
+    "scripts": {
+        "clean": "rm -Rf node_modules/ *.js",
+        "build": "tsc",
+        "test": "npm run build && node dist/client.js"
     }
 }

--- a/version.ts
+++ b/version.ts
@@ -1,0 +1,3 @@
+// x-release-please-start-version
+export const VERSION = '1.0.0';
+// x-release-please-end


### PR DESCRIPTION
* Add version file, to be consumed by generated SDK files for use in User-Agent
* Add package.json to sdk generator ignore, to prevent overwriting version
* Update package.json details to reference correct values
  * Uses Stripe package.json as reference: https://github.com/stripe/stripe-node/blob/master/package.json